### PR TITLE
Add sql query source location to trace event field

### DIFF
--- a/spec/connection_adapters/honeycomb_adapter_spec.rb
+++ b/spec/connection_adapters/honeycomb_adapter_spec.rb
@@ -21,6 +21,12 @@ RSpec.shared_examples_for 'records a database query' do |name:, preceding_events
     expect(sql).to include(quote_table_name(table))
   end
 
+  it 'records the SQL query source' do
+    expect(last_event.data).to include('db.query_source')
+    source = last_event.data['db.query_source']
+    expect(source).to match(/\w+\.rb:\d+:in `\w+'/)
+  end
+
   # active record 4 and mysql doesn't support parameterised queries
   unless ENV["DB_ADAPTER"] == "mysql2" && ActiveRecord.version < Gem::Version.new("5")
     it 'records the parameterised SQL query rather than the literal parameter values' do


### PR DESCRIPTION
Rails 5.2 adds a "verbose query logs" option that will log the line in the app that triggered a query to be run. I've copied that functionality (using activesupport's backtrace_cleaner to find the relevant line, which is how Rails 6.0 accomplishes it) into the connection adapter so the Trace's query details can expose it.