### PR TITLE
Return the munged config if it has already been munged

### DIFF
--- a/lib/active_record/honeycomb.rb
+++ b/lib/active_record/honeycomb.rb
@@ -6,6 +6,8 @@ module ActiveRecord
       def munge_config(config, client: nil, logger: nil)
         config = resolve_config(config)
 
+        return config if config.key?('real_adapter') || config.key?(:real_adapter)
+
         munged = config.merge(
           'adapter' => 'honeycomb',
           'real_adapter' => config.fetch('adapter'),


### PR DESCRIPTION
When using the PGHero gem, which tries to establish its own connection,
the `#munge_config` monkeypatch gets called again. For some reason,
however, this time through the keys in the hash are symbols instead of
strings, so the `config.fetch('adapter')` fails.

We probably do not want to re-munge the config again anyways (so that
both 'adapter' and 'real_adapter' would == 'honeycomb'), so just return
the config if we detect that its already been munged.